### PR TITLE
20756: default value of foreach is now FALSE and not field.contains('*')

### DIFF
--- a/src/main/java/com/groupeseb/kite/check/Check.java
+++ b/src/main/java/com/groupeseb/kite/check/Check.java
@@ -1,10 +1,12 @@
 package com.groupeseb.kite.check;
 
-import com.groupeseb.kite.CreationLog;
-import com.groupeseb.kite.Json;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
 import org.json.simple.parser.ParseException;
+
+import com.groupeseb.kite.CreationLog;
+import com.groupeseb.kite.Json;
 
 @Getter
 @Slf4j
@@ -32,7 +34,7 @@ public class Check {
         operatorName = (checkSpecification.getString("operator") == null) ? "equals" : checkSpecification.getString("operator");
         expectedValue = creationLog.processPlaceholders(checkSpecification.getObject("expected"));
         parameters = checkSpecification.get("parameters");
-        foreach = checkSpecification.getBooleanOrDefault("foreach", fieldName.contains("*"));
+		foreach = checkSpecification.getBooleanOrDefault("foreach", false);
         mustMatch = checkSpecification.getBooleanOrDefault("mustMatch", foreach);
         skip = checkSpecification.getBooleanOrDefault("skip", false);
     }


### PR DESCRIPTION
NE PAS MERGER DIRECTEMENT, il faut:
* modifier par conséquence et rejouer tous les tests d'intégration qui se basent sur cette règle
* faire une montée de version majeure à cause de la non-retrocompatibilité

Julien est en train de faire des corrections sur Kite donc je pense qu'il faut attendre qu'il ait terminé avant de faire une montée de version.