### PR TITLE
Allow placeholders in fieldName

### DIFF
--- a/src/main/java/com/groupeseb/kite/check/Check.java
+++ b/src/main/java/com/groupeseb/kite/check/Check.java
@@ -19,6 +19,7 @@ public class Check {
 	private final Boolean mustMatch;
 	private final Boolean skip;
 
+	@SuppressWarnings("ConstantConditions")
 	public Check(Json checkSpecification, ContextProcessor context) throws ParseException {
 		checkSpecification.checkExistence("field", "expected");
 
@@ -27,7 +28,7 @@ public class Check {
 		}
 
 		description = (checkSpecification.getString("description") == null) ? "" : checkSpecification.getString("description");
-		fieldName = checkSpecification.getString("field");
+		fieldName = (checkSpecification.getString("field") == null) ? null : context.processPlaceholdersInString(checkSpecification.getString("field"));
 		methodName = (checkSpecification.getString("method") == null) ? "nop" : checkSpecification.getString("method");
 		operatorName = (checkSpecification.getString("operator") == null) ? "equals" : checkSpecification.getString("operator");
 		expectedValue = context.processPlaceholders(checkSpecification.getObject("expected"));

--- a/src/main/java/com/groupeseb/kite/check/Check.java
+++ b/src/main/java/com/groupeseb/kite/check/Check.java
@@ -27,10 +27,10 @@ public class Check {
 			log.warn("'description' field is missing in one of your check.");
 		}
 
-		description = (checkSpecification.getString("description") == null) ? "" : checkSpecification.getString("description");
-		fieldName = (checkSpecification.getString("field") == null) ? null : context.processPlaceholdersInString(checkSpecification.getString("field"));
-		methodName = (checkSpecification.getString("method") == null) ? "nop" : checkSpecification.getString("method");
-		operatorName = (checkSpecification.getString("operator") == null) ? "equals" : checkSpecification.getString("operator");
+		description = checkSpecification.getStringOrDefault("description", "");
+		fieldName = context.processPlaceholdersInString(checkSpecification.getString("field"));
+		methodName = checkSpecification.getStringOrDefault("method", "nop");
+		operatorName = checkSpecification.getStringOrDefault("operator", "equals");
 		expectedValue = context.processPlaceholders(checkSpecification.getObject("expected"));
 		parameters = checkSpecification.get("parameters");
 		foreach = checkSpecification.getBooleanOrDefault("foreach", false);

--- a/src/test/java/com/groupeseb/kite/ScenarioRunnerTest.java
+++ b/src/test/java/com/groupeseb/kite/ScenarioRunnerTest.java
@@ -15,6 +15,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -157,6 +159,15 @@ public class ScenarioRunnerTest {
 		stubForUrlAndBody(POST, "/nullBodyUrl", 201, null);
 
 		KiteRunner.getInstance().execute("testExecute_06.json");
+	}
+
+	@Test
+	public void testKiteContext_07() throws Exception {
+		Map<Object, Object> response = new HashMap<>();
+		response.put("anAttribute", "aValue");
+		stubForUrlAndBody(POST, "/myUrl07", 201, response);
+
+		KiteRunner.getInstance().execute("testExecute_07.json");
 	}
 
 	@AllArgsConstructor

--- a/src/test/resources/testExecute_07.json
+++ b/src/test/resources/testExecute_07.json
@@ -1,0 +1,32 @@
+{
+	"description": "Use placeholders in field attribute",
+	"variables": {
+		"fieldVariable": "anAttribute"
+	},
+	"commands": [
+		{
+			"verb": "POST",
+			"uri": "/myUrl07",
+			"automaticCheck": false,
+			"checks": [
+				{
+					"description": "Placeholder is correctly executed",
+					"field": "{{Variable:fieldVariable}}",
+					"expected": "aValue"
+				}
+			]
+		},
+		{
+			"verb": "POST",
+			"uri": "/myUrl07",
+			"automaticCheck": false,
+			"checks": [
+				{
+					"description": "No placeholder still works",
+					"field": "$.anAttribute",
+					"expected": "aValue"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
One can use placeholders (Variable, Lookup...) in fieldName inside Check construct