### PR TITLE
Add a parameter on command to disable URL params value encoding

### DIFF
--- a/src/main/java/com/groupeseb/kite/Command.java
+++ b/src/main/java/com/groupeseb/kite/Command.java
@@ -82,6 +82,13 @@ class Command {
 	private final Boolean debug;
 
 	/**
+	 * Indicate if the HTTP client must URL Encode parameter's values before issuing the request
+	 * Used with all verbs
+	 * Optional. Default to true
+	 */
+	private final Boolean urlEncodingEnabled;
+	
+	/**
 	 * Defines headers which will be added to the HTTP call.
 	 * Maybe empty.
 	 */
@@ -132,7 +139,8 @@ class Command {
 		automaticCheck = commandSpecification.getBooleanOrDefault("automaticCheck",
 		                                                          expectedStatus.toString().startsWith("2"));
 		debug = commandSpecification.getBooleanOrDefault("debug", false);
-
+		urlEncodingEnabled = commandSpecification.getBooleanOrDefault("urlEncodingEnabled", true);
+		
 		if (commandSpecification.exists("pagination")) {
 			pagination = new Pagination(requireNonNull(commandSpecification.get("pagination")));
 		}

--- a/src/main/java/com/groupeseb/kite/CommandRunner.java
+++ b/src/main/java/com/groupeseb/kite/CommandRunner.java
@@ -88,10 +88,11 @@ public class CommandRunner {
 	void post(Command command, ContextProcessor contextProcessor) throws ParseException {
 		String processedURI = contextProcessor.getProcessedURI(command);
 		log.info("[ {} ] POST {} (expecting {})", command.getName(), processedURI, command.getExpectedStatus());
-
+		
 		Response postResponse = contextProcessor.initRequestSpecificationContent(command)
 				.contentType(APPLICATION_JSON.toString())
 				.headers(contextProcessor.getProcessedHeaders(command))
+				.urlEncodingEnabled(command.getUrlEncodingEnabled())
 				.when()
 				.post(processedURI);
 
@@ -120,6 +121,7 @@ public class CommandRunner {
 		log.info("Checking resource: " + location + "...");
 		given().header("Accept-Encoding", APPLICATION_JSON.getCharset().toString())
 				.headers(contextProcessor.getProcessedHeadersForCheck(command))
+                .urlEncodingEnabled(command.getUrlEncodingEnabled())
 				.expect().statusCode(HttpStatus.SC_OK)
 				.when().get(location);
 
@@ -136,6 +138,7 @@ public class CommandRunner {
 		Response patchResponse = contextProcessor.initRequestSpecificationContent(command)
 				.contentType(APPLICATION_JSON.toString())
 				.headers(contextProcessor.getProcessedHeaders(command))
+                .urlEncodingEnabled(command.getUrlEncodingEnabled())
 				.when()
 				.patch(processedURI);
 
@@ -167,6 +170,7 @@ public class CommandRunner {
 
 		Response response = given().contentType(APPLICATION_JSON.toString())
 				.headers(mapHeaders)
+                .urlEncodingEnabled(command.getUrlEncodingEnabled())
 				.expect().statusCode(command.getExpectedStatus())
 				.when().get(processedURI);
 
@@ -224,6 +228,7 @@ public class CommandRunner {
 				.headers(contextProcessor.getProcessedHeaders(command))
 				.log()
 				.everything(true)
+                .urlEncodingEnabled(command.getUrlEncodingEnabled())
 				.expect()
 				.statusCode(command.getExpectedStatus())
 				.when()
@@ -248,6 +253,7 @@ public class CommandRunner {
 				.headers(contextProcessor.getProcessedHeaders(command))
 				.log()
 				.everything(true)
+                .urlEncodingEnabled(command.getUrlEncodingEnabled())
 				.expect()
 				.statusCode(expectedStatus)
 				.when()
@@ -259,6 +265,7 @@ public class CommandRunner {
 
 		if (command.getAutomaticCheck()) {
 			given().contentType(APPLICATION_JSON.toString())
+                    .urlEncodingEnabled(command.getUrlEncodingEnabled())
 					.expect().statusCode(HttpStatus.SC_NOT_FOUND)
 					.when().get(processedURI);
 		}


### PR DESCRIPTION
Ajout d'un paramètre au niveau des commande pour ne pas encoder les paramètres d'URL.

RestAssured les encode par défaut, cela fait qu'il n'était pas possible de passer certains caractères spéciaux dans l'URL (par exemple "&"). Si encode le caractère dans l'URI du fichier JSON du scénario (& => %26), RestAssured réencodait (%26 => %2526), ce qui n'envoyait pas la bonne valeur dans l'appel du test. Pour le cas du "&", si on encode pas, l'URL n'est pas valide.

Pour être rétro compatible, j'ai mis la valeur par défaut du paramètre à "true" dans la commande, pour ne pas avoir à modifier les scénarios existants.

**Est-ce qu'il serait possible de faire une release 3.16 de kite après validation de la pull request** ?